### PR TITLE
Allow HomeBridge owner to override check for Flagged data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Example config.json
           "name": "PurpleAir Air Quality",
           "statsKey": "v",
           "adjust": "NONE",
-          "includePM10": true
+          "includePM10": true,
+          "allowFlaggedData": false
     }
 ]
 ```
@@ -42,6 +43,7 @@ Fields:
 - `statsKey` Selects the key from the sensor to report. The sensor reports various time based averages which can be selected. These are: v (real time), v1 (10 minute average), v2 (30 minute average), v3 (1 hour average), v4 (6 hour average), v5 (24 hour average), v6 (1 week average).
 - `adjust` Adjust the raw PM2.5 value based on various algorithms. These are: NONE (raw values), EPA, LRAPA and AQANDU.
 - `includePM10` Include PM10 measurements in the AQI calculation. The highest AQI calculated from PM2.5 and PM10 will be used to calculate the air quality. The AQI calculations from PM2.5 and PM10 are not the same. Value should be a literal true or false, not string quoted.
+- `allowFlaggedData` Allows sensor data to be used even if it has been flagged by PurpleAir as potentially erroneous.
 
 To find your specific "PURPLE_AIR_STATION_ID" (a string):
 1. Use the PurpleAir Map to locate a station (https://www.purpleair.com/map)

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function PurpleAirAccessory(log, config) {
 			break;
 	}
 	this.lastupdate = 0;
+	this.allowFlaggedData = config.allowFlaggedData;
 
 	this.updateFreq = config.updateFreq;
 	if (!this.updateFreq) {
@@ -112,12 +113,14 @@ PurpleAirAccessory.prototype = {
 			dataB = data.results[1];
 		}
 
-		// Select only valid data
-		if (dataA.Flag == 1) {
-			dataA = undefined;
-		}
-		if (dataB && dataB.Flag == 1) {
-			dataB = undefined;
+		// Select only valid data unless explicitly allowed
+		if (!this.allowFlaggedData) {
+			if (dataA.Flag == 1) {
+				dataA = undefined;
+			}
+			if (dataB && dataB.Flag == 1) {
+				dataB = undefined;
+			}
 		}
 
 		// No valid data


### PR DESCRIPTION
For whatever reason, PurpleAir seems to always mark the data on my private sensor as flagged, though the data quality seems fine (and is certainly still useful. This change allows me to bypass this check while keeping default behavior unchanged.
